### PR TITLE
Fix "Use of '@import' when modules are disabled"

### DIFF
--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -1,5 +1,4 @@
 #import "NativeSettings.h"
-@import UIKit;
 
 @implementation NativeSettings
 


### PR DESCRIPTION
Modules are enabled by default in new projects since Xcode 5.