### PR TITLE
Fix for new Cordova 7 behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativesettingsopener",
-  "version": "1.2",
+  "version": "1.3.0",
   "description": "Native settings opener for Cordova 3.0",
   "cordova": {
     "id": "com.phonegap.plugins.nativesettingsopener",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="com.phonegap.plugins.nativesettingsopener"
-	version="1.3">
+	version="1.3.0">
 
 	<name>Native settings</name>
 	<description>Native settings opener for Cordova 4.0</description>


### PR DESCRIPTION
This fix is necessary to allow new Cordova 7 to install this plugin with the "fetch" flag set to true (new default behaviour). Otherwise th einstallation will trow a "Invalid Version: 1.2" error.

I moved version in package.json to 1.3.0, feel free to edit that to a desired version.