### PR TITLE
Fix/plugin package id sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ It will be saved to the config.xml file
 Ionic Framework:
 
 ```bash
-ionic cordova plugin (add|rm) cordova-open-native-settings --save
+ionic cordova plugin (add|rm) net.gsrweb.cordova.plugins.cordovaopennativesettings
 ```
 
 Cordova:
 
 ```bash
-cordova plugin (add|rm) cordova-open-native-settings --save
+cordova plugin (add|rm) net.gsrweb.cordova.plugins.cordovaopennativesettings --save
 ```
 
 or via npm (It will be saved to the package.json file)
 
 ```bash
-npm (install|rm) cordova-open-native-settings --save
+npm (install|rm) net.gsrweb.cordova.plugins.cordovaopennativesettings --save
 ```
 
 ## Using the plugin (opens Location Settings in Android and Application Settings in iOS)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-open-native-settings",
+  "name": "net.gsrweb.cordova.plugins.cordovaopennativesettings",
   "version": "1.3.0",
   "description": "Native settings opener for Cordova",
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "net.gsrweb.cordova.plugins.cordovaopennativesettings",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Native settings opener for Cordova",
   "cordova": {
     "id": "net.gsrweb.cordova.plugins.cordovaopennativesettings",


### PR DESCRIPTION
It turns out that while the publish to NPM solved our Ionic/Cordova resolution errors, Cordova has some behaviour where it updates `package.json` with each plugin as a Dependency, along with updating `config.xml` with the usual plugin details.

Because this repo is published at https://www.npmjs.com/package/cordova-open-native-settings, `npm install cordova-open-native-settings` causes this repo to be added to `package.json` as this:

```
"dependencies": {
...
  "cordova-open-native-settings": "~1.3.0",
...
}
```

However when Cordova reconciles the plugin repo on npmjs.com (`cordova-open-native-settings`) it adds the plugin ID to `package.json` instead of the NPM repo name, which creates this:

```
"dependencies": {
...
  "cordova-open-native-settings": "~1.3.0",
  "com.phonegap.plugins.nativesettingsopener": "^1.3.0",
...
}
```

This new `package.json` now fails to `npm install` because the plugin ID as a dependency isn't an actual NPM package.

I think the plugin needs to be published to NPM as its plugin ID, not as the `package.json` name. To confirm this behaviour, I published the plugin to a private registry:

![plugin in private registry](https://user-images.githubusercontent.com/1182187/28241688-1783dff8-694e-11e7-9cb9-c73ceb7983e6.jpg)

After adjusting my project to pull from this private registry, the install process worked _mostly_ as expected:

```
# ionic cordova plugin add com.phonegap.plugins.nativesettingsopener
✔ Creating ./www directory for you - done!
> cordova plugin add com.phonegap.plugins.nativesettingsopener --save
✔ Running command - done!
Adding net.gsrweb.cordova.plugins.cordovaopennativesettings to package.json
Saved plugin info for "net.gsrweb.cordova.plugins.cordovaopennativesettings" to config.xml
```

... but as you can see, Cordova parses the NPM repo and adds the plugin ID to `package.json`, and in this case `net.gsrweb.cordova.plugins.cordovaopennativesettings` is not a valid repository so if this change gets committed, any build after this point will result in a failure to obtain the plugin.

This PR is a 2-step fix for these problems. Contained here are some changes:

- Unified `package.json` name with plugin ID
- Breaking/Minor version bump due to package renaming
- Adjusted the README to reference the new install steps

... and to make this fully functional, this plugin will need to be published to NPM as its plugin ID (`net.gsrweb.cordova.plugins.cordovaopennativesettings`). Now that the `package.json` name is the same as the plugin ID, the procedure is simply `npm publish` after merging this PR.

@guyromb as maintainer of this project, I think it makes sense for you to perform the merge and publish! Please let me know if it's a hassle and perhaps we can publish in a different way.