### PR TITLE
Feat/android bat opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can use any constant from the following list:
     "application_development", // android
     "application", // android
     "autolock", // ios
+    "battery_optimization", // android
     "bluetooth", // ios, android
     "castle", // ios
     "captioning", // android

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "engines": [
     {
       "name": "cordova",
-      "version": ">=3.0.0"
+      "version": ">=4.0.0"
     }
   ],
   "author": "Guy Rombaut <admin@gsrweb.net>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cordova-open-native-settings",
-  "version": "1.3.0",
+  "name": "net.gsrweb.cordova.plugins.cordovaopennativesettings",
+  "version": "1.4.1",
   "description": "Native settings opener for Cordova",
   "cordova": {
     "id": "net.gsrweb.cordova.plugins.cordovaopennativesettings",
@@ -41,6 +41,9 @@
     },
     {
       "username": "perlish"
+    },
+    {
+      "username": "emcniece"
     }
   ],
   "license": "MIT",

--- a/src/android/NativeSettings.java
+++ b/src/android/NativeSettings.java
@@ -53,7 +53,9 @@ public class NativeSettings extends CordovaPlugin {
         //else if (action.equals("battery_saver")) {
         //    intent = new Intent(android.provider.Settings.ACTION_BATTERY_SAVER_SETTINGS);
         //}
-        else if (action.equals("bluetooth")) {
+        else if (action.equals("battery_optimization")) {
+            intent = new Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+        } else if (action.equals("bluetooth")) {
             intent = new Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS);
         } else if (action.equals("captioning")) {
             intent = new Intent(android.provider.Settings.ACTION_CAPTIONING_SETTINGS);


### PR DESCRIPTION
Adds a setting page for Battery Optimization on Android.

[Android reference page](https://developer.android.com/reference/android/provider/Settings.html#ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)

Expecting PR https://github.com/guyromb/Cordova-open-native-settings/pull/10 to be merged first.

Resolves https://github.com/guyromb/Cordova-open-native-settings/issues/4