### PR TITLE
Add options description in doc and improve iOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,82 +49,109 @@ if (window.cordova && window.cordova.plugins.settings) {
 In Android, by default it is opened in the same application as a new activity, the hardware back button will bring the user back to the previous activity (the app). In order to open settings as a new application (two applications will appear in "recent/opened" apps list) the following code can be used:
 `window.cordova.plugins.settings.open(["wifi", true], function() {}, function() {}); ....`
 
-## Settings Options
-You can use any constant from the following list:
-* I tried to map Android and iOS together, however, they are not always the same.
+## Settings Options (Android)
 
-```
-    "about", // ios
-    "accessibility", // ios, android
-    "account", // ios, android
-    "airplane_mode", // ios, android
-    "apn", // android
-    "application_details", // ios, android
-    "application_development", // android
-    "application", // android
-    "autolock", // ios
-    "battery_optimization", // android
-    "bluetooth", // ios, android
-    "castle", // ios
-    "captioning", // android
-    "cast", // android
-    "cellular_usage", // ios
-    "configuration_list", // ios
-    "data_roaming", // android
-    "date", // ios, android
-    "display", // ios, android
-    "dream", // android
-    "facetime", // ios
-    "home", // android
-    "keyboard", // ios, android
-    "keyboard_subtype", // android
-    "locale", // ios, android
-    "location", // ios, android
-    "locations", // ios
-    "manage_all_applications", // android
-    "manage_applications", // android
-    "memory_card", // android
-    "music", // ios
-    "music_equalizer", // ios
-    "music_volume", // ios
-    "network", // ios, android
-    "nike_ipod", // ios
-    "nfcsharing", // android
-    "nfc_payment", // android
-    "nfc_settings", // android
-    "notes", // ios
-    "notification_id", // ios
-    "passbook", // ios
-    "phone", // ios
-    "photos", // ios
-    "print", // android
-    "privacy", // android
-    "quick_launch", // android
-    "reset", // ios
-    "ringtone", // ios
-    "browser", // ios
-    "search", // ios, android
-    "security", // android
-    "settings", // ios, android
-    "show_regulatory_info",
-    "sound", // ios, android
-    "software_update", // ios
-    "storage", // ios, android
-    "store", // ios, android
-    "sync", // android
-    "tethering", // ios
-    "twitter", // ios
-    "touch", // ios
-    "usage", // ios, android
-    "user_dictionary", // android
-    "video", // ios
-    "voice_input", // android
-    "vpn", // ios
-    "wallpaper", // ios
-    "wifi_ip", // android
-    "wifi", // ios, android
-    "wireless" // android
-```
+Setting constant | Description
+-----------------|------------
+"accessibility" | Show settings for accessibility modules
+"account" | Show add account screen for creating a new account
+"airplane_mode" | Show settings to allow entering/exiting airplane mode
+"apn" | Show settings to allow configuration of APNs
+"application_details" | Show screen of details about a particular application
+"application_development" | Show settings to allow configuration of application development-related settings
+"application" | Show settings to allow configuration of application-related settings
+"battery_optimization" | Show screen for controlling which apps can ignore battery optimizations
+"bluetooth" | Show settings to allow configuration of Bluetooth
+"captioning" | Show settings for video captioning
+"cast" | Show settings to allow configuration of cast endpoints
+"data_roaming" | Show settings for selection of 2G/3G
+"date" | Show settings to allow configuration of date and time
+"display" | Show settings to allow configuration of display
+"dream" | Show Daydream settings
+"home" | Show Home selection settings
+"keyboard" | Show settings to configure input methods, in particular allowing the user to enable input methods
+"keyboard_subtype" | Show settings to enable/disable input method subtypes
+"locale" | Show settings to allow configuration of locale
+"location" | Show settings to allow configuration of current location sources
+"manage_all_applications" | Show settings to manage all applications
+"manage_applications" | Show settings to manage installed applications
+"memory_card" | Show settings for memory card storage
+"network" | Show settings for selecting the network operator
+"nfcsharing" | Show NFC Sharing settings
+"nfc_payment" | Show NFC Tap & Pay settings
+"nfc_settings" | Show NFC settings
+"print" | Show the top level print settings
+"privacy" | Show settings to allow configuration of privacy options
+"quick_launch" | Show settings to allow configuration of quick launch shortcuts
+"search" | Show settings for global search
+"security" | Show settings to allow configuration of security and location privacy
+"settings" | Show system settings
+"show_regulatory_info" | Show the regulatory information screen for the device
+"sound" | Show settings to a llow configuration of sound and volume
+"storage" | Show settings for internal storage
+"store" | Open the Play Store page of the current application
+"sync" | Show settings to allow configuration of sync settings
+"usage" | Show settings to control access to usage information
+"user_dictionary" | Show settings to manage the user input dictionary
+"voice_input" | Show settings to configure input methods, in particular allowing the user to enable input methods
+"wifi_ip" | Show settings to allow configuration of a static IP address for Wi-Fi
+"wifi" | Show settings to allow configuration of Wi-Fi
+"wireless" | Show settings to allow configuration of wireless controls such as Wi-Fi, Bluetooth and Mobile networks
+
+
+## Settings Options (iOS)
+
+Setting constant | Description
+-----------------|------------
+"about" | Settings > General > About
+"accessibility" | Settings > General > Accessibility
+"account" | Settings > _Your name_
+"airplane_mode" | Settings > Airplane Mode
+"application_details" | Settings
+"autolock" | Settings > General > Auto-Lock (before iOS 10)
+"battery" | Settings > Battery
+"bluetooth" | Settings > General > Bluetooth (before iOS 9)<br>Settings > Bluetooth (after iOS 9)
+"browser" | Settings > Safari
+"castle" | Settings > iCloud
+"cellular_usage" | Settings > General > Cellular Usage
+"configuration_list" | Settings > General > Profile
+"date" | Settings > General > Date & Time
+"display" | Settings > Display & Brightness
+"do_not_disturb" | Settings > Do Not Disturb
+"facetime" | Settings > Facetime
+"keyboard" | Settings > General > Keyboard
+"keyboards" | Settings > General > Keyboard > Keyboards
+"locale" | Settings > General > Language & Region
+"location" | Settings > Location Services (in older versions of iOS)
+"locations" | Settings > Privacy > Location Services (in newer versions of iOS)
+"mobile_data" | Settings > Mobile Data (after iOS 10)
+"music" | Settings > iTunes
+"music_equalizer" | Settings > Music > EQ
+"music_volume" | Settings > Music > Volume Limit
+"network" | Settings > General > Network
+"nike_ipod" | Settings > Nike + iPod
+"notes" | Settings > Notes
+"notification_id" | Settings > Notifications
+"passbook" | Settings > Passbook & Apple Pay
+"phone" | Settings > Phone
+"photos" | Settings > Photo & Camera
+"privacy" | Settings > Privacy
+"reset" | Settings > General > Reset
+"ringtone" | Settings > Sounds > Ringtone
+"search" | Settings > General > Assistant (before iOS 10)<br>Settings > Siri (after iOS 10)
+"settings" | Settings > General
+"sound" | Settings > Sounds
+"software_update" | Settings > General > Software Update
+"storage" | Settings > iCloud > Storage & Backup
+"store" | Settings > iTunes & App Store
+"tethering" | Settings > Personal Hotspot
+"touch" | Settings > Touch ID & Passcode
+"twitter" | Settings > Twitter
+"usage" | Settings > General > Storage & iCloud Usage
+"video" | Settings > Video
+"vpn" | Settings > General > VPN
+"wallpaper" | Settings > Wallpaper
+"wifi" | Settings > WIFI
 
 ## Notes
 * Android plugin based on the following information: https://developer.android.com/reference/android/provider/Settings.html#ACTION_DREAM_SETTINGS

--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -40,13 +40,23 @@
 		result = [self do_open:[prefix stringByAppendingString:@"root=AIRPLANE_MODE"]];
 	}
 	else if ([key isEqualToString:@"autolock"]) {
-		result = [self do_open:[prefix stringByAppendingString:@"root=General&path=AUTOLOCK"]];
+		if (SYSTEM_VERSION_LESS_THAN(@"10.0")) {
+			result = [self do_open:[prefix stringByAppendingString:@"root=General&path=AUTOLOCK"]];
+		}
+		else {
+			result = [self do_open:[prefix stringByAppendingString:@"root=DISPLAY&path=AUTOLOCK"]];
+		}
 	}
 	else if ([key isEqualToString:@"display"]) {
 		result = [self do_open:[prefix stringByAppendingString:@"root=Brightness"]];
 	}
 	else if ([key isEqualToString:@"bluetooth"]) {
-		result = [self do_open:[prefix stringByAppendingString:@"root=Bluetooth"]];
+		if (SYSTEM_VERSION_LESS_THAN(@"9.0")) {
+			result = [self do_open:[prefix stringByAppendingString:@"root=General&path=Bluetooth"]];
+		}
+		else {
+			result = [self do_open:[prefix stringByAppendingString:@"root=Bluetooth"]];
+		}
 	}
 	else if ([key isEqualToString:@"castle"]) {
 		result = [self do_open:[prefix stringByAppendingString:@"root=CASTLE"]];
@@ -121,7 +131,12 @@
 		result = [self do_open:[prefix stringByAppendingString:@"root=Safari"]];
 	}
 	else if ([key isEqualToString:@"search"]) {
-		result = [self do_open:[prefix stringByAppendingString:@"root=General&path=Assistant"]];
+		if (SYSTEM_VERSION_LESS_THAN(@"10.0")) {
+			result = [self do_open:[prefix stringByAppendingString:@"root=General&path=Assistant"]];
+		}
+		else {
+			result = [self do_open:[prefix stringByAppendingString:@"root=SIRI"]];
+		}
 	}
 	else if ([key isEqualToString:@"sound"]) {
 		result = [self do_open:[prefix stringByAppendingString:@"root=Sounds"]];
@@ -153,6 +168,21 @@
 	else if ([key isEqualToString:@"touch"]) {
 	    result = [self do_open:[prefix stringByAppendingString:@"root=TOUCHID_PASSCODE"]];
 	}	
+	else if ([key isEqualToString:@"battery"]) {
+		result = [self do_open:[prefix stringByAppendingString:@"root=BATTERY_USAGE"]];
+	}
+	else if ([key isEqualToString:@"privacy"]) {
+		result = [self do_open:[prefix stringByAppendingString:@"root=Privacy"]];
+	}
+	else if ([key isEqualToString:@"do_not_disturb"]) {
+		result = [self do_open:[prefix stringByAppendingString:@"root=General&path=DO_NOT_DISTURB"]];
+	}
+	else if ([key isEqualToString:@"keyboards"]) {
+		result = [self do_open:[prefix stringByAppendingString:@"root=General&path=Keyboard/KEYBOARDS"]];
+	}
+	else if ([key isEqualToString:@"mobile_data"]) {
+		result = [self do_open:[prefix stringByAppendingString:@"root=MOBILE_DATA_SETTINGS_ID"]];
+	}
 	else {
 		pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid Action"];
 	}


### PR DESCRIPTION
- Added descriptions for iOS and Android options;
- Added support for older/newer versions of iOS for `autolock`, `bluetooth` and `search` options;
- Added iOS options: `battery`, `privacy`, `do_not_disturb`, `keyboards `and `mobile_data`.

Could you also update the NPM package? It doesn't include the patch for the iOS `touch` option. Thanks!