### PR TITLE
Fix Doesn't work in IOS 11

### DIFF
--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -21,6 +21,10 @@
 		prefix = @"prefs:";
 	}
 	
+	if (@available(iOS 11.0, *)) {
+        	prefix = @"app-settings:";
+    	}
+	
     if ([key isEqualToString:@"application_details"]) {
         result = [self do_open:UIApplicationOpenSettingsURLString];
     }


### PR DESCRIPTION
Hello.
I corrected the source using the method on this page and I was able to open notification settings for a specific application.

https://stackoverflow.com/questions/46253781/ios-11-url-scheme-for-specific-settings-section-stopped-working