### PR TITLE
Switch back to open General phone settings on iOS ^11.3

### DIFF
--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -17,13 +17,13 @@
 	NSString* prefix = @"App-Prefs:";
 	BOOL result = NO;
 
+	if(SYSTEM_VERSION_LESS_THAN(@"11.3")){
+        prefix = @"app-settings:";
+    }
+
 	if(SYSTEM_VERSION_LESS_THAN(@"10.0")){
 		prefix = @"prefs:";
 	}
-	
-	if (@available(iOS 11.0, *)) {
-        	prefix = @"app-settings:";
-    	}
 	
     if ([key isEqualToString:@"application_details"]) {
         result = [self do_open:UIApplicationOpenSettingsURLString];


### PR DESCRIPTION
Instead of open the app settings, opens the general phone settings by default