### PR TITLE
Fix reject iOS with this drastic message

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,18 +33,6 @@
 				<param name="ios-package" value="NativeSettings"/>
 			</feature>
 		</config-file>
-		<config-file target="*-Info.plist" parent="CFBundleURLTypes">
-			<array>
-				<dict>
-					<key>CFBundleTypeRole</key>
-					<string>Editor</string>
-					<key>CFBundleURLSchemes</key>
-					<array>
-						<string>prefs</string>
-					</array>
-				</dict>
-			</array>
-		</config-file>
 
 		<header-file src="src/ios/NativeSettings.h" />
 		<source-file src="src/ios/NativeSettings.m" />

--- a/src/ios/NativeSettings.m
+++ b/src/ios/NativeSettings.m
@@ -21,9 +21,6 @@
         prefix = @"app-settings:";
     }
 
-	if(SYSTEM_VERSION_LESS_THAN(@"10.0")){
-		prefix = @"prefs:";
-	}
 	
     if ([key isEqualToString:@"application_details"]) {
         result = [self do_open:UIApplicationOpenSettingsURLString];


### PR DESCRIPTION
Fix reject iOS with this drastic message:

Your app uses the "prefs:root=" non-public URL scheme, which is a private entity. The use of non-public APIs is not permitted on the App Store because it can lead to a poor user experience should these APIs change.

Continuing to use or conceal non-public APIs in future submissions of this app may result in the termination of your Apple Developer account, as well as removal of all associated apps from the App Store.

Fix #36 

I tested it in iOS 9 - iOS11 and this works