### PR TITLE
Fix Android 13 biometric enrollment crash

### DIFF
--- a/src/android/NativeSettings.java
+++ b/src/android/NativeSettings.java
@@ -27,7 +27,7 @@ public class NativeSettings extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-		Context context=this.cordova.getActivity().getApplicationContext();
+	Context context = this.cordova.getActivity().getApplicationContext();
         PluginResult.Status status = PluginResult.Status.OK;
         Uri packageUri = Uri.parse("package:" + this.cordova.getActivity().getPackageName());
         String result = "";
@@ -35,8 +35,8 @@ public class NativeSettings extends CordovaPlugin {
         //Information on settings can be found here:
         //http://developer.android.com/reference/android/provider/Settings.html
 		
-		action = args.getString(0);
-		Intent intent = null;
+	action = args.getString(0);
+	Intent intent = null;
 
         if (action.equals("accessibility")) {
             intent = new Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS);
@@ -59,12 +59,9 @@ public class NativeSettings extends CordovaPlugin {
         else if (action.equals("battery_optimization")) {
             intent = new Intent(android.provider.Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
         } else if (action.equals("biometric")) {
-
-            intent = new Intent();
-            // Uncomment the below code when Cordova supports Android 30 / R
-			/*if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
+	    if(android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.R){
                 intent = new Intent(android.provider.Settings.ACTION_BIOMETRIC_ENROLL);
-            } else */ if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 intent = new Intent(android.provider.Settings.ACTION_FINGERPRINT_ENROLL);
             } else {
                 // Atleast open the settings landing page


### PR DESCRIPTION
This fixes the issue where when we try to open biometric settings on Android 13 the settings app crashes. See #57 and #67 